### PR TITLE
Bypassing pixel buffer attributes 

### DIFF
--- a/ARVideoKit/Rendering/Writer/WritAR.swift
+++ b/ARVideoKit/Rendering/Writer/WritAR.swift
@@ -64,7 +64,7 @@ class WritAR: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate {
         videoInput = AVAssetWriterInput(mediaType: .video, outputSettings: videoOutputSettings)
 
         videoInput.expectsMediaDataInRealTime = true
-        pixelBufferInput = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: videoInput, sourcePixelBufferAttributes: attributes)
+        pixelBufferInput = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: videoInput, sourcePixelBufferAttributes: nil)
         
         var angleEnabled: Bool {
             for v in orientaions {


### PR DESCRIPTION
To resolve recordings not working on iPhone X/XS/XMax devices.