### PR TITLE
Deprecated swift_version file

### DIFF
--- a/.swift-version
+++ b/.swift-version
@@ -1,1 +1,0 @@
-echo "4.0" > .swift-version

--- a/ARVideoKit.podspec
+++ b/ARVideoKit.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.description  = "Enabling developers to capture videos 📹, photos 🌄, Live Photos 🎇, and GIFs 🎆 with augmented reality components."
   s.homepage     = "https://github.com/AFathi/ARVideoKit"
   s.screenshots  = "http://www.ahmedbekhit.com/SK_PREV.gif", "http://www.ahmedbekhit.com/SCN_PREVIEW.gif"
-
+  s.swift_version = '4.2'
 
 
   s.license      = { :type => "Apache 2.0", :file => "LICENSE" }


### PR DESCRIPTION
**CHANGES**

- Remove the ".swift-version" file which is now deprecated and only use the "swift_version" attribute within your podspec.


**DOUBT**

I need to include this framework as dependency in a private pod which works in Swift 4.2. Could you publish this version public as soon as you can?.

If not and you has some idea about this problem I am glad to hear you ;)

Thanks so much. Amazing work!!! :D 