### PR TITLE
Fix memory leaks

### DIFF
--- a/ARVideoKit.xcodeproj/project.pbxproj
+++ b/ARVideoKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B466A8B82279E34C00BD7070 /* WeakProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B466A8B72279E34C00BD7070 /* WeakProxy.swift */; };
 		FB2E36891FAE29C00035B8D6 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = FB2E36881FAE29BF0035B8D6 /* LICENSE */; };
 		FB404FFE20D72A190056EA1D /* JPEG.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB404FFD20D72A190056EA1D /* JPEG.swift */; };
 		FBD604DF1FA969DD00EC9804 /* ARVideoKit.h in Headers */ = {isa = PBXBuildFile; fileRef = FBD604DD1FA969DD00EC9804 /* ARVideoKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -33,6 +34,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		B466A8B72279E34C00BD7070 /* WeakProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakProxy.swift; sourceTree = "<group>"; };
 		FB2E36881FAE29BF0035B8D6 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		FB404FFD20D72A190056EA1D /* JPEG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JPEG.swift; sourceTree = "<group>"; };
 		FBD604DA1FA969DD00EC9804 /* ARVideoKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ARVideoKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -71,6 +73,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B466A8B62279E33800BD7070 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				B466A8B72279E34C00BD7070 /* WeakProxy.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		FBA0AA0A1FAD9D9D006C481B /* Writer */ = {
 			isa = PBXGroup;
 			children = (
@@ -99,6 +109,7 @@
 		FBD604DC1FA969DD00EC9804 /* ARVideoKit */ = {
 			isa = PBXGroup;
 			children = (
+				B466A8B62279E33800BD7070 /* Utils */,
 				FBD604E51FA96ACD00EC9804 /* Assets */,
 				FBD604E61FA96AD400EC9804 /* Enumerations */,
 				FBD604E71FA96AE500EC9804 /* Extensions */,
@@ -290,6 +301,7 @@
 				FBD604F51FA96B3300EC9804 /* UIImage+VideoBuffer.swift in Sources */,
 				FBD605111FA96BA100EC9804 /* ARView.swift in Sources */,
 				FBD604F61FA96B3300EC9804 /* CGImage+Resize.swift in Sources */,
+				B466A8B82279E34C00BD7070 /* WeakProxy.swift in Sources */,
 				FBD604F91FA96B3300EC9804 /* UIViewController+hasType.swift in Sources */,
 				FBD605141FA96BA100EC9804 /* ViewAR.swift in Sources */,
 				FBD604EE1FA96B2700EC9804 /* ARVideoOptions.swift in Sources */,

--- a/ARVideoKit/Rendering/RenderAR.swift
+++ b/ARVideoKit/Rendering/RenderAR.swift
@@ -9,11 +9,10 @@
 import Foundation
 import ARKit
 
-private var view: Any?
-private var renderEngine: SCNRenderer!
-
 @available(iOS 11.0, *)
 struct RenderAR {
+    private var view: Any?
+    private var renderEngine: SCNRenderer!
     var ARcontentMode: ARFrameMode!
     
     init(_ ARview: Any?, renderer: SCNRenderer, contentMode: ARFrameMode) {

--- a/ARVideoKit/Rendering/Writer/WritAR.swift
+++ b/ARVideoKit/Rendering/Writer/WritAR.swift
@@ -25,7 +25,7 @@ class WritAR: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate {
 
     private var isRecording: Bool = false
     
-    var delegate: RecordARDelegate?
+    weak var delegate: RecordARDelegate?
     var videoInputOrientation: ARVideoOrientation = .auto
 
     init(output: URL, width: Int, height: Int, adjustForSharing: Bool, audioEnabled: Bool, orientaions:[ARInputViewOrientation], queue: DispatchQueue, allowMix: Bool) {

--- a/ARVideoKit/Sources/ARView.swift
+++ b/ARVideoKit/Sources/ARView.swift
@@ -20,7 +20,7 @@ import ARKit
  */
 @available(iOS 11.0, *)
 @objc public class ARView: NSObject {
-    private var parentVC: UIViewController?
+    private weak var parentVC: UIViewController?
     private var recentAngle = 0
     private var inputViewOrientation:[ARInputViewOrientation] = []
     

--- a/ARVideoKit/Sources/RecordAR.swift
+++ b/ARVideoKit/Sources/RecordAR.swift
@@ -12,13 +12,6 @@ import ARKit
 import Photos
 import PhotosUI
 
-private var view: Any?
-private var renderEngine: SCNRenderer!
-private var gpuLoop: CADisplayLink!
-private var isResting = false
-private var ARcontentMode: ARFrameMode!
-@available(iOS 11.0, *)
-private var renderer: RenderAR!
 /**
  This class renders the `ARSCNView` or `ARSKView` content with the device's camera stream to generate a video 📹, photo 🌄, live photo 🎇 or GIF 🎆.
 
@@ -162,6 +155,13 @@ private var renderer: RenderAR!
     let audioSessionQueue = DispatchQueue(label: "com.ahmedbekhit.AudioSessionQueue", attributes: .concurrent)
     
     //MARK: - Objects
+    private var view: Any?
+    private var renderEngine: SCNRenderer!
+    private var gpuLoop: CADisplayLink!
+    private var isResting = false
+    private var ARcontentMode: ARFrameMode!
+    private var renderer: RenderAR!
+
     private var scnView: SCNView!
     private var fileCount = 0
     

--- a/ARVideoKit/Sources/RecordAR.swift
+++ b/ARVideoKit/Sources/RecordAR.swift
@@ -782,8 +782,10 @@ extension RecordAR {
 
                 self.adjustPausedTime = false
                 
-                if self.pausedFrameTime != nil {
-                    self.pausedFrameTime = self.adjustTime(current: time, resume: self.resumeFrameTime!, pause: self.pausedFrameTime!)
+                if self.pausedFrameTime != nil && self.resumeFrameTime != nil {
+                    self.pausedFrameTime = self.adjustTime(current: time,
+                                                           resume: self.resumeFrameTime!,
+                                                           pause: self.pausedFrameTime!)
                 } else {
                     self.pausedFrameTime = time
                 }

--- a/ARVideoKit/Sources/RecordAR.swift
+++ b/ARVideoKit/Sources/RecordAR.swift
@@ -148,6 +148,11 @@ import PhotosUI
         view = SceneKit
         setup()
     }
+
+    //MARK: - Deinit
+    deinit {
+        gpuLoop.invalidate()
+    }
     
     //MARK: - threads
     let writerQueue = DispatchQueue(label:"com.ahmedbekhit.WriterQueue")
@@ -220,8 +225,9 @@ import PhotosUI
             }
             renderEngine = SCNRenderer(device: mtlDevice, options: nil)
             renderEngine.scene = view.scene
-            
-            gpuLoop = CADisplayLink(target: self, selector: #selector(renderFrame))
+
+            gpuLoop = CADisplayLink(target: WeakProxy(target: self),
+                                    selector: #selector(renderFrame))
             gpuLoop.preferredFramesPerSecond = fps.rawValue
             gpuLoop.add(to: .main, forMode: .common)
             
@@ -243,8 +249,9 @@ import PhotosUI
             
             renderEngine = SCNRenderer(device: mtlDevice, options: nil)
             renderEngine.scene = scnView.scene
-            
-            gpuLoop = CADisplayLink(target: self, selector: #selector(renderFrame))
+
+            gpuLoop = CADisplayLink(target: WeakProxy(target: self),
+                                    selector: #selector(renderFrame))
             gpuLoop.preferredFramesPerSecond = fps.rawValue
             gpuLoop.add(to: .main, forMode: .common)
             
@@ -256,8 +263,9 @@ import PhotosUI
             }
             renderEngine = SCNRenderer(device: mtlDevice, options: nil)
             renderEngine.scene = view.scene
-            
-            gpuLoop = CADisplayLink(target: self, selector: #selector(renderFrame))
+
+            gpuLoop = CADisplayLink(target: WeakProxy(target: self),
+                                    selector: #selector(renderFrame))
             gpuLoop.preferredFramesPerSecond = fps.rawValue
             gpuLoop.add(to: .main, forMode: .common)
             

--- a/ARVideoKit/Utils/WeakProxy.swift
+++ b/ARVideoKit/Utils/WeakProxy.swift
@@ -1,0 +1,26 @@
+//
+//  SSSS.swift
+//  ARVideoKit
+//
+//  Created by Saul Moreno Abril on 01/05/2019.
+//  Copyright © 2019 Ahmed Fathit Bekhit. All rights reserved.
+//
+
+import Foundation
+
+class WeakProxy: NSObject {
+    weak var target: NSObjectProtocol?
+
+    init(target: NSObjectProtocol) {
+        self.target = target
+        super.init()
+    }
+
+    override func responds(to aSelector: Selector!) -> Bool {
+        return (target?.responds(to: aSelector) ?? false) || super.responds(to: aSelector)
+    }
+
+    override func forwardingTarget(for aSelector: Selector!) -> Any? {
+        return target
+    }
+}


### PR DESCRIPTION
FIX MEMORY LEAKS:
- Parent view reference must be weak
- Use weak proxy to broke memory leak with CADisplayLink
- Use private properties in place of global 