### PR TITLE
Fix PHLivePhoto in Xcode 11 (iOS 13 SDK) error : `'init()' has been xplicitly marked unavailable here (Photos.PHLivePhoto)`

### DIFF
--- a/ARVideoKit/Rendering/Live Photo/PHLivePhotoPlus.swift
+++ b/ARVideoKit/Rendering/Live Photo/PHLivePhotoPlus.swift
@@ -18,7 +18,7 @@ import Photos
  * [Email](mailto:me@ahmedbekhit.com)
  */
 @available(iOS 9.1, *)
-@objc public class PHLivePhotoPlus: PHLivePhoto {
+@objc public class PHLivePhotoPlus: NSObject {
     var pairedVideoPath: URL?
     var keyPhotoPath: URL?
     


### PR DESCRIPTION
#87 