### PR TITLE
Add SCNTechnique retaining support

### DIFF
--- a/ARVideoKit/Sources/RecordAR.swift
+++ b/ARVideoKit/Sources/RecordAR.swift
@@ -118,9 +118,9 @@ import PhotosUI
                 guard let techniqueSupportingView = view as? SCNTechniqueSupport else {
                     return
                 }
-                renderEngine.technique = techniqueSupportingView.technique
+                renderEngine?.technique = techniqueSupportingView.technique
             } else {
-                renderEngine.technique = nil
+                renderEngine?.technique = nil
             }
         }
     }

--- a/ARVideoKit/Sources/RecordAR.swift
+++ b/ARVideoKit/Sources/RecordAR.swift
@@ -109,6 +109,21 @@ import PhotosUI
             }
         }
     }
+    /**
+     A boolean that indicates whether render engine should retain SCNTechnique used in the view. Default is `false`.
+     */
+    @objc public var retainTechnique: Bool = false {
+        didSet {
+            if retainTechnique {
+                guard let techniqueSupportingView = view as? SCNTechniqueSupport else {
+                    return
+                }
+                renderEngine.technique = techniqueSupportingView.technique
+            } else {
+                renderEngine.technique = nil
+            }
+        }
+    }
     
     //MARK: - Public initialization methods
     /**


### PR DESCRIPTION
Currently the SCNTechnique of recorded view isn't being assigned to the rendering engine, which may result in differences between what is rendered on the screen and what is recorded in the video. 
This PR introduces a flag which controls whether SCNTechnique should be assigned from the view to the rendering engine.