### PR TITLE
Fix iPhone X Max, XS Max, 11Pro Max size recording size problem.

### DIFF
--- a/ARVideoKit/Extensions/UIView+isType.swift
+++ b/ARVideoKit/Extensions/UIView+isType.swift
@@ -15,8 +15,7 @@ extension UIScreen {
      `isiPhone10` is a boolean that returns if the device is iPhone X or not.
      */
     var isNotch: Bool {
-        let bottom = UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0
-        return bottom > 0
+      return UIApplication.shared.keyWindow?.safeAreaInsets != UIEdgeInsets.zero
     }
 }
 @available(iOS 11.0, *)

--- a/ARVideoKit/Extensions/UIView+isType.swift
+++ b/ARVideoKit/Extensions/UIView+isType.swift
@@ -14,8 +14,9 @@ extension UIScreen {
     /**
      `isiPhone10` is a boolean that returns if the device is iPhone X or not.
      */
-    var isiPhone10: Bool {
-        return self.nativeBounds.size == CGSize(width: 1125, height: 2436) || self.nativeBounds.size == CGSize(width: 2436, height: 1125)
+    var isNotch: Bool {
+        let bottom = UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0
+        return bottom > 0
     }
 }
 @available(iOS 11.0, *)

--- a/ARVideoKit/Rendering/RenderAR.swift
+++ b/ARVideoKit/Rendering/RenderAR.swift
@@ -44,7 +44,7 @@ struct RenderAR {
         if let contentMode = ARcontentMode {
             switch contentMode {
             case .auto:
-                if UIScreen.main.isiPhone10 {
+                if UIScreen.main.isNotch {
                     width = Int(UIScreen.main.nativeBounds.width)
                     height = Int(UIScreen.main.nativeBounds.height)
                 }
@@ -62,7 +62,7 @@ struct RenderAR {
                 width = Int(targetSize.width)
                 height = Int(targetSize.height)
             default:
-                if UIScreen.main.isiPhone10 {
+                if UIScreen.main.isNotch {
                     width = Int(UIScreen.main.nativeBounds.width)
                     height = Int(UIScreen.main.nativeBounds.height)
                 }


### PR DESCRIPTION
Fix iPhone X Max, XS Max, 11Pro Max size recording size problem. Renewing "isiPhone10" extension to "isNotch".

I have a problem in recording Max device. The record video size was 1080x1920. So i fix the problem.
Check my code.