### PR TITLE
adjust when to set renderer.ARcontentMode

### DIFF
--- a/ARVideoKit/Sources/RecordAR.swift
+++ b/ARVideoKit/Sources/RecordAR.swift
@@ -172,7 +172,6 @@ import PhotosUI
     private var renderEngine: SCNRenderer!
     private var gpuLoop: CADisplayLink!
     private var isResting = false
-    private var ARcontentMode: ARFrameMode!
     private var renderer: RenderAR!
 
     private var scnView: SCNView!
@@ -725,7 +724,7 @@ import PhotosUI
      - parameter configuration: An object that defines motion and scene tracking behaviors for the session.
     */
     @objc func prepare(_ configuration: ARConfiguration? = nil) {
-        ARcontentMode = contentMode
+        renderer.ARcontentMode = contentMode
         onlyRenderWhileRec = onlyRenderWhileRecording
         if let view = view as? ARSCNView {
             UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
@@ -761,6 +760,8 @@ extension RecordAR {
         //frame rendering
         if self.onlyRenderWhileRec && !isRecording && !isRecordingGIF { return }
 
+        renderer.ARcontentMode = contentMode
+
         guard let buffer = renderer.buffer else { return }
         guard let rawBuffer = renderer.rawBuffer else {
             logAR.message("ERROR:- An error occurred while rendering the camera's main buffers.")
@@ -770,7 +771,6 @@ extension RecordAR {
             logAR.message("ERROR:- An error occurred while rendering the camera buffer.")
             return
         }
-        renderer.ARcontentMode = contentMode
 
         self.writerQueue.sync {
             


### PR DESCRIPTION
1.  set `renderer.ARContentMode` in `prepare` method
2. set  `renderer.ARContentMode` in `renderFrame` method before call `renderer.buffer`
3. property `ARcontentMode` of `RecordAR` class is not used so delete it 